### PR TITLE
Fix for OID name and increase in PON query interval

### DIFF
--- a/template_dmos_gpon_counting/dmos_gpon_counting_mib_zabbix_template.xml
+++ b/template_dmos_gpon_counting/dmos_gpon_counting_mib_zabbix_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>4.4</version>
-    <date>2023-11-29T13:21:41Z</date>
+    <date>2023-12-05T13:43:34Z</date>
     <groups>
         <group>
             <name>DM - Templates</name>
@@ -33,7 +33,7 @@
                     <name>Global Down Onus</name>
                     <type>SNMPV2</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <snmp_oid>.1.3.6.1.4.1.3709.3.6.18.1.4.0</snmp_oid>
+                    <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfGlobalDownOnus.0</snmp_oid>
                     <key>ponIfGlobalDownOnus</key>
                     <delay>10m</delay>
                     <applications>
@@ -46,7 +46,7 @@
                     <name>Global Non Provisioned Onus</name>
                     <type>SNMPV2</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <snmp_oid>.1.3.6.1.4.1.3709.3.6.18.1.2.0</snmp_oid>
+                    <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfGlobalNonProvisionedOnus.0</snmp_oid>
                     <key>ponIfGlobalNonProvisionedOnus</key>
                     <delay>10m</delay>
                     <applications>
@@ -59,7 +59,7 @@
                     <name>Global Total Onus</name>
                     <type>SNMPV2</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <snmp_oid>.1.3.6.1.4.1.3709.3.6.18.1.1.0</snmp_oid>
+                    <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfGlobalTotalOnus.0</snmp_oid>
                     <key>ponIfGlobalTotalOnus</key>
                     <delay>10m</delay>
                     <applications>
@@ -72,7 +72,7 @@
                     <name>Global Up Onus</name>
                     <type>SNMPV2</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <snmp_oid>.1.3.6.1.4.1.3709.3.6.18.1.3.0</snmp_oid>
+                    <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfGlobalUpOnus.0</snmp_oid>
                     <key>ponIfGlobalUpOnus</key>
                     <delay>10m</delay>
                     <applications>
@@ -98,6 +98,7 @@
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfDownOnus.{#SNMPINDEX}</snmp_oid>
                             <key>pon.if[ponIfDownOnus.{#SNMPINDEX}]</key>
+                            <delay>10m</delay>
                             <applications>
                                 <application>
                                     <name>ONU-Couting</name>
@@ -110,6 +111,7 @@
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfNonProvisionedOnus.{#SNMPINDEX}</snmp_oid>
                             <key>pon.if[ponIfNonProvisionedOnus.{#SNMPINDEX}]</key>
+                            <delay>10m</delay>
                             <applications>
                                 <application>
                                     <name>ONU-Couting</name>
@@ -122,6 +124,7 @@
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfTotalOnus.{#SNMPINDEX}</snmp_oid>
                             <key>pon.if[ponIfTotalOnus.{#SNMPINDEX}]</key>
+                            <delay>10m</delay>
                             <applications>
                                 <application>
                                     <name>ONU-Couting</name>
@@ -134,6 +137,7 @@
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfUpOnus.{#SNMPINDEX}</snmp_oid>
                             <key>pon.if[ponIfUpOnus.{#SNMPINDEX}]</key>
+                            <delay>10m</delay>
                             <applications>
                                 <application>
                                     <name>ONU-Couting</name>


### PR DESCRIPTION
- Updated the SNMP OID field to use the name available in the MIB.
- Increased query interval to reduce OLT CPU consumption.