### PR TITLE
Improve zabbix performance using get asynchronous mode

### DIFF
--- a/template_datacom_if-mib/dm_if_mib_zabbix_template.xml
+++ b/template_datacom_if-mib/dm_if_mib_zabbix_template.xml
@@ -60,7 +60,7 @@
                             <uuid>c1ae066f29e5487aab3bfd58e9eaf3b7</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Bits received</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifHCInOctets.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifHCInOctets.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifHCInOctets.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <units>bps</units>
@@ -86,7 +86,7 @@
                             <uuid>a45471565be64083a5e1d5c15492b518</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Bits sent</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifHCOutOctets.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifHCOutOctets.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifHCOutOctets.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <units>bps</units>
@@ -112,7 +112,7 @@
                             <uuid>25df7996eb454ad4ae411eea6b0d18a9</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Speed</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifHighSpeed.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifHighSpeed.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifHighSpeed.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <trends>0</trends>
@@ -136,7 +136,7 @@
                             <uuid>066a36d913404260bea44f737f6859a7</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Inbound broadcast packets</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifInBroadcastPkts.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifInBroadcastPkts.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifInBroadcastPkts.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <preprocessing>
@@ -155,7 +155,7 @@
                             <uuid>3fc2a2010f8f493397ff16e811881824</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Inbound packets discarded</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifInDiscards.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifInDiscards.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifInDiscards.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <preprocessing>
@@ -174,7 +174,7 @@
                             <uuid>23ddb5d24a294bf08fc63b2b7aa1f738</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Inbound packets with errors</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifInErrors.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifInErrors.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifInErrors.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <preprocessing>
@@ -193,7 +193,7 @@
                             <uuid>274097998bb44042b8399a33dc911158</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Inbound multicast packets</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifInMulticastPkts.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifInMulticastPkts.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifInMulticastPkts.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <preprocessing>
@@ -212,7 +212,7 @@
                             <uuid>bfb80211a43246e3bf465953215189c6</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Inbound unicast packets</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifInUcastPkts.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifInUcastPkts.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifInUcastPkts.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <preprocessing>
@@ -231,7 +231,7 @@
                             <uuid>fa7263b8fa1249778f173751a2679069</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Operational Status</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifOperStatus.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifOperStatus.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifOperStatus.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <trends>0</trends>
@@ -267,7 +267,7 @@ WARNING: if closed manually - won't fire again on next poll, because of .diff.</
                             <uuid>7bcd47f57b5a4357b6134688a7b475dc</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Outbound broadcast packets</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifOutBroadcastPkts.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifOutBroadcastPkts.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifOutBroadcastPkts.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <preprocessing>
@@ -286,7 +286,7 @@ WARNING: if closed manually - won't fire again on next poll, because of .diff.</
                             <uuid>4e6ce93b536b4b76a985c3014017a9b1</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Outbound packets discarded</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifOutDiscards.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifOutDiscards.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifOutDiscards.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <preprocessing>
@@ -305,7 +305,7 @@ WARNING: if closed manually - won't fire again on next poll, because of .diff.</
                             <uuid>0da7038b64d34d5a8fd655f0ef043025</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Outbound packets with errors</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifOutErrors.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifOutErrors.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifOutErrors.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <preprocessing>
@@ -324,7 +324,7 @@ WARNING: if closed manually - won't fire again on next poll, because of .diff.</
                             <uuid>97e075f050654aa499aead9cc4dd2507</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Outbound multicast packets</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifOutMulticastPkts.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifOutMulticastPkts.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifOutMulticastPkts.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <preprocessing>
@@ -343,7 +343,7 @@ WARNING: if closed manually - won't fire again on next poll, because of .diff.</
                             <uuid>2248252cdd8248d48e3b44acce2a99e6</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Outbound unicast packets</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifOutUcastPkts.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifOutUcastPkts.{#SNMPINDEX}]</snmp_oid>
                             <key>net.if[ifOutUcastPkts.{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <preprocessing>

--- a/template_dmos/dmos_zabbix_template.xml
+++ b/template_dmos/dmos_zabbix_template.xml
@@ -22,7 +22,7 @@
                     <uuid>1be4ce9791d54069bcb7cbea974bb709</uuid>
                     <name>Device contact details</name>
                     <type>SNMP_AGENT</type>
-                    <snmp_oid>SNMPv2-MIB::sysContact.0</snmp_oid>
+                    <snmp_oid>get[SNMPv2-MIB::sysContact.0]</snmp_oid>
                     <key>sysContact</key>
                     <delay>60m</delay>
                     <history>7d</history>
@@ -40,7 +40,7 @@
                     <uuid>8a199ce2fe874a42ad6decf1780ca78c</uuid>
                     <name>Device description</name>
                     <type>SNMP_AGENT</type>
-                    <snmp_oid>SNMPv2-MIB::sysDescr.0</snmp_oid>
+                    <snmp_oid>get[SNMPv2-MIB::sysDescr.0]</snmp_oid>
                     <key>sysDescr</key>
                     <delay>60m</delay>
                     <history>7d</history>
@@ -58,7 +58,7 @@
                     <uuid>a06bad5c19c34f33bb47bf5bd4d502c7</uuid>
                     <name>Device location</name>
                     <type>SNMP_AGENT</type>
-                    <snmp_oid>SNMPv2-MIB::sysLocation.0</snmp_oid>
+                    <snmp_oid>get[SNMPv2-MIB::sysLocation.0]</snmp_oid>
                     <key>sysLocation</key>
                     <delay>60m</delay>
                     <history>7d</history>
@@ -76,7 +76,7 @@
                     <uuid>94ff72edd27f4b9ab6cffbad828c0a46</uuid>
                     <name>Device name</name>
                     <type>SNMP_AGENT</type>
-                    <snmp_oid>SNMPv2-MIB::sysName.0</snmp_oid>
+                    <snmp_oid>get[SNMPv2-MIB::sysName.0]</snmp_oid>
                     <key>sysName</key>
                     <delay>60m</delay>
                     <history>7d</history>
@@ -94,7 +94,7 @@
                     <uuid>2fcbe0e771e9486e9efab72e5957d635</uuid>
                     <name>Device uptime</name>
                     <type>SNMP_AGENT</type>
-                    <snmp_oid>SNMPv2-MIB::sysUpTime.0</snmp_oid>
+                    <snmp_oid>get[SNMPv2-MIB::sysUpTime.0]</snmp_oid>
                     <key>sysUpTime</key>
                     <delay>60m</delay>
                     <history>7d</history>
@@ -129,7 +129,7 @@
                             <uuid>e62ebf9ebd1944a6ab60a8f4169b4558</uuid>
                             <name>{#PSU_SLOT_NAME} Status</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-HW-MONITOR-MIB::psuStatus.{#PSU_SLOT_NAME_LEN}.{#PSU_SLOT_NAME_DEC}</snmp_oid>
+                            <snmp_oid>get[DMOS-HW-MONITOR-MIB::psuStatus.{#PSU_SLOT_NAME_LEN}.{#PSU_SLOT_NAME_DEC}]</snmp_oid>
                             <key>psuStatus.[{#PSU_SLOT_NAME}]</key>
                             <delay>5m</delay>
                             <valuemap>
@@ -170,7 +170,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>491c570661af443c9b49667188511c4d</uuid>
                             <name>Active CPU core last 5 minutes</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreFiveMinutesActive.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreFiveMinutesActive.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreFiveMinutesActive[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -196,7 +196,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>132383e9e55240dd8502a84de7c63deb</uuid>
                             <name>Interrupt CPU core last 5 minutes</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreFiveMinutesInterrupt.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreFiveMinutesInterrupt.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreFiveMinutesInterrupt[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -213,7 +213,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>05f2be6e985b436087e101c4d2207f0f</uuid>
                             <name>Nice CPU core last 5 minutes</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreFiveMinutesNice.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreFiveMinutesNice.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreFiveMinutesNIce[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -230,7 +230,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>c7853eed2ada40b39a120df1ab33f10e</uuid>
                             <name>Softirq CPU core last 5 minutes</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreFiveMinutesSoftirq.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreFiveMinutesSoftirq.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreFiveMinutesSoftirq[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -247,7 +247,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>e333a496f208458ca44bef810ee0aeaa</uuid>
                             <name>System CPU core last 5 minutes</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreFiveMinutesSystem.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreFiveMinutesSystem.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreFiveMinutesSystem[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -264,7 +264,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>8099b51c69714c4ebd66aabc6eca5b6f</uuid>
                             <name>User CPU core last 5 minutes</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreFiveMinutesUser.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreFiveMinutesUser.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreFiveMinutesUser[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -281,7 +281,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>ca246c8e6622429da4107784ee03094e</uuid>
                             <name>Wait CPU core last 5 minutes</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreFiveMinutesWait.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreFiveMinutesWait.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreFiveMinutesWait[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -298,7 +298,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>613d71f6410d49f680bee481374deb70</uuid>
                             <name>Active CPU core last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreOneMinuteActive.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreOneMinuteActive.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreOneMinuteActive[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <trends>7d</trends>
@@ -314,7 +314,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>9f70fd1ffa7344ab990154e5d9d24e58</uuid>
                             <name>Interrupt CPU core last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreOneMinuteInterrupt.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreOneMinuteInterrupt.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreOneMinuteInterrupt[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <trends>7d</trends>
@@ -330,7 +330,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>ff7d3c90e25c4952ab939bea53f0ec33</uuid>
                             <name>Nice CPU core last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreOneMinuteNice.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreOneMinuteNice.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreOneMinuteNice[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <trends>7d</trends>
@@ -346,7 +346,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>e8129ecfdd0a4db8ac46258c76ba0c34</uuid>
                             <name>Softirq CPU core last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreOneMinuteSoftirq.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreOneMinuteSoftirq.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreOneMinuteSoftirq[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <trends>7d</trends>
@@ -362,7 +362,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>744cff73fc9c42e387cec88cf936433d</uuid>
                             <name>System CPU core last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreOneMinuteSystem.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreOneMinuteSystem.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreOneMinuteSystem[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <trends>7d</trends>
@@ -378,7 +378,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>dd87dff25d2a41549a543c608a9b3744</uuid>
                             <name>User CPU core last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreOneMinuteUser.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreOneMinuteUser.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreOneMinuteUser[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <trends>7d</trends>
@@ -394,7 +394,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>c62128b6b9054fe4873ff2b957e7c299</uuid>
                             <name>Wait CPU core last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuCoreOneMinuteWait.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuCoreOneMinuteWait.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuCoreOneMinuteWait[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <trends>7d</trends>
@@ -586,7 +586,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>22d9889cec8747d6932c33d2edb5976c</uuid>
                             <name>Active CPU load last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::cpuLoadOneMinuteActive.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::cpuLoadOneMinuteActive.{#SNMPINDEX}]</snmp_oid>
                             <key>cpuLoadOneMinuteActive[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <trends>7d</trends>
@@ -660,7 +660,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>85c8b9c9371b47178c2e8d6099200c9b</uuid>
                             <name>FAN {#SNMPVALUE} Read Error</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-HW-MONITOR-MIB::fanSpeedReadError.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-HW-MONITOR-MIB::fanSpeedReadError.{#SNMPINDEX}]</snmp_oid>
                             <key>fanSpeedReadError[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -687,7 +687,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>0972093fea884e26a7452f5036460845</uuid>
                             <name>FAN {#SNMPVALUE} Status</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-HW-MONITOR-MIB::fanSpeedStatus.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-HW-MONITOR-MIB::fanSpeedStatus.{#SNMPINDEX}]</snmp_oid>
                             <key>fanSpeedStatus[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -714,7 +714,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>9fc69cce18e84c1d85fa5efbdadb4d02</uuid>
                             <name>FAN {#SNMPVALUE} Speed</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-HW-MONITOR-MIB::fanSpeed.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-HW-MONITOR-MIB::fanSpeed.{#SNMPINDEX}]</snmp_oid>
                             <key>fanSpeed[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -757,7 +757,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>9d537e29460e428f9169a3d796a214ff</uuid>
                             <name>Available memory last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::memoryOneMinuteAvailable.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::memoryOneMinuteAvailable.{#SNMPINDEX}]</snmp_oid>
                             <key>memoryOneMinuteAvailable[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <tags>
@@ -779,7 +779,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>edc7f012d8724b03aa20eb99de32e289</uuid>
                             <name>Buffered memory last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::memoryOneMinuteBuffered.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::memoryOneMinuteBuffered.{#SNMPINDEX}]</snmp_oid>
                             <key>memoryOneMinuteBuffered[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <tags>
@@ -793,7 +793,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>df14fa98d534484ab321f998fb4c2c19</uuid>
                             <name>Cached memory last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::memoryOneMinuteCached.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::memoryOneMinuteCached.{#SNMPINDEX}]</snmp_oid>
                             <key>memoryOneMinuteCached[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <tags>
@@ -807,7 +807,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>5ba5cdb21116499a8398dd8e54eb9b59</uuid>
                             <name>Free memory last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::memoryOneMinuteFree.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::memoryOneMinuteFree.{#SNMPINDEX}]</snmp_oid>
                             <key>memoryOneMinuteFree[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <tags>
@@ -821,7 +821,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>9aa8523273394621b0f502293a0b9b94</uuid>
                             <name>Slab Reclaimed last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::memoryOneMinuteSlabRecl.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::memoryOneMinuteSlabRecl.{#SNMPINDEX}]</snmp_oid>
                             <key>memoryOneMinuteSlabRecl[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <tags>
@@ -835,7 +835,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>af8b261c3f1e4d3c85ad7479763ad55f</uuid>
                             <name>Slab Unreclaimed last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::memoryOneMinuteSlabUnrecl.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::memoryOneMinuteSlabUnrecl.{#SNMPINDEX}]</snmp_oid>
                             <key>memoryOneMinuteSlabUnrecl[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <tags>
@@ -849,7 +849,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>f136f3ee130e4dec9daeda6b9ac64f53</uuid>
                             <name>Total memory last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::memoryOneMinuteTotal.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::memoryOneMinuteTotal.{#SNMPINDEX}]</snmp_oid>
                             <key>memoryOneMinuteTotal[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <tags>
@@ -863,7 +863,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>e86ab2742a2d47339108916eb35f4548</uuid>
                             <name>Used memory last 1 minute</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-SYSMON-MIB::memoryOneMinuteUsed.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-SYSMON-MIB::memoryOneMinuteUsed.{#SNMPINDEX}]</snmp_oid>
                             <key>memoryOneMinuteUsed[{#SNMPINDEX}]</key>
                             <history>7d</history>
                             <tags>
@@ -961,7 +961,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>7241fac1bb4447c496804521b73b7696</uuid>
                             <name>Sensor {#SNMPVALUE} - Current Temperature</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-HW-MONITOR-MIB::temperatureSensorCurrentTemperature.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-HW-MONITOR-MIB::temperatureSensorCurrentTemperature.{#SNMPINDEX}]</snmp_oid>
                             <key>temperatureSensorCurrentTemperature[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -986,7 +986,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>16d5cbdcfa1b4a92b7d65e73ac28411c</uuid>
                             <name>Sensor {#SNMPVALUE} - Description</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-HW-MONITOR-MIB::temperatureSensorDescription.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-HW-MONITOR-MIB::temperatureSensorDescription.{#SNMPINDEX}]</snmp_oid>
                             <key>temperatureSensorDescription[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -1002,7 +1002,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>3bbfa7b76c244d97bdbe9a539fdf3a34</uuid>
                             <name>Sensor {#SNMPVALUE} - Hysteresis Temperature</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-HW-MONITOR-MIB::temperatureSensorHysteresis.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-HW-MONITOR-MIB::temperatureSensorHysteresis.{#SNMPINDEX}]</snmp_oid>
                             <key>temperatureSensorHysteresis[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -1027,7 +1027,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>5dabcb3db4814f27a9de10582b703566</uuid>
                             <name>Sensor {#SNMPVALUE} - Max Temperature</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-HW-MONITOR-MIB::temperatureSensorMaxTemperature.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-HW-MONITOR-MIB::temperatureSensorMaxTemperature.{#SNMPINDEX}]</snmp_oid>
                             <key>temperatureSensorMaxTemperature[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -1052,7 +1052,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>71518956d93b4110b5233884274b3e49</uuid>
                             <name>Sensor {#SNMPVALUE} - Min Temperature</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-HW-MONITOR-MIB::temperatureSensorMinTemperature.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-HW-MONITOR-MIB::temperatureSensorMinTemperature.{#SNMPINDEX}]</snmp_oid>
                             <key>temperatureSensorMinTemperature[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>
@@ -1077,7 +1077,7 @@ Trigger activate if PSU Status is different from OK (0) and difference between p
                             <uuid>8222bbb62050449fbffda137d90b32a3</uuid>
                             <name>Sensor {#SNMPVALUE} - Read Error</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-HW-MONITOR-MIB::temperatureSensorTemperatureReadError.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-HW-MONITOR-MIB::temperatureSensorTemperatureReadError.{#SNMPINDEX}]</snmp_oid>
                             <key>temperatureSensorTemperatureReadError[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>7d</history>

--- a/template_dmos_bgp4/dmos_bgp4_mib_zabbix_template.xml
+++ b/template_dmos_bgp4/dmos_bgp4_mib_zabbix_template.xml
@@ -39,7 +39,7 @@
                             <uuid>0b74b49158ee47f398c72e1de25661cc</uuid>
                             <name>BGP In Accepted Prefixes for Peer {#IP_ADDRESS} AFI {#AFI} SAFI {#SAFI}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-BGP4-MIB::bgpPrefixCountersInAcceptedPrefixes.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}</snmp_oid>
+                            <snmp_oid>get[DMOS-BGP4-MIB::bgpPrefixCountersInAcceptedPrefixes.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}]</snmp_oid>
                             <key>bgpPrefixCountersInAcceptedPrefixes.[{#IP_ADDRESS}.{#AFI}.{#SAFI}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -53,7 +53,7 @@
                             <uuid>01237fea9fcb4691b31644b93aa6f882</uuid>
                             <name>BGP In Active Prefixes for Peer {#IP_ADDRESS} AFI {#AFI} SAFI {#SAFI}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-BGP4-MIB::bgpPrefixCountersInActivePrefixes.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}</snmp_oid>
+                            <snmp_oid>get[DMOS-BGP4-MIB::bgpPrefixCountersInActivePrefixes.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}]</snmp_oid>
                             <key>bgpPrefixCountersInActivePrefixes.[{#IP_ADDRESS}.{#AFI}.{#SAFI}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -67,7 +67,7 @@
                             <uuid>db2e8ac938c941278dd06431701bd497</uuid>
                             <name>BGP In Prefixes for Peer {#IP_ADDRESS} AFI {#AFI} SAFI {#SAFI}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-BGP4-MIB::bgpPrefixCountersInPrefixes.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}</snmp_oid>
+                            <snmp_oid>get[DMOS-BGP4-MIB::bgpPrefixCountersInPrefixes.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}]</snmp_oid>
                             <key>bgpPrefixCountersInPrefixes.[{#IP_ADDRESS}.{#AFI}.{#SAFI}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -81,7 +81,7 @@
                             <uuid>df5f02101d904a44854277cc14bc4510</uuid>
                             <name>BGP In Prefixes Denied By Policer for Peer {#IP_ADDRESS} AFI {#AFI} SAFI {#SAFI}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-BGP4-MIB::bgpPrefixCountersInPrefixesDeniedByPol.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}</snmp_oid>
+                            <snmp_oid>get[DMOS-BGP4-MIB::bgpPrefixCountersInPrefixesDeniedByPol.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}]</snmp_oid>
                             <key>bgpPrefixCountersInPrefixesDeniedByPol.[{#IP_ADDRESS}.{#AFI}.{#SAFI}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -95,7 +95,7 @@
                             <uuid>e97f7bfb47bf41cdaad989fc346f7b65</uuid>
                             <name>BGP In Rejected Prefixes for Peer {#IP_ADDRESS} AFI {#AFI} SAFI {#SAFI}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-BGP4-MIB::bgpPrefixCountersInRejectedPrefixes.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}</snmp_oid>
+                            <snmp_oid>get[DMOS-BGP4-MIB::bgpPrefixCountersInRejectedPrefixes.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}]</snmp_oid>
                             <key>bgpPrefixCountersInRejectedPrefixes.[{#IP_ADDRESS}.{#AFI}.{#SAFI}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -109,7 +109,7 @@
                             <uuid>8fa9838d929d4fd5ab330f824ff70856</uuid>
                             <name>BGP Out Advertised Prefixes for Peer {#IP_ADDRESS} AFI {#AFI} SAFI {#SAFI}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-BGP4-MIB::bgpPrefixCountersOutAdvertisedPrefixes.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}</snmp_oid>
+                            <snmp_oid>get[DMOS-BGP4-MIB::bgpPrefixCountersOutAdvertisedPrefixes.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}]</snmp_oid>
                             <key>bgpPrefixCountersOutAdvertisedPrefixes.[{#IP_ADDRESS}.{#AFI}.{#SAFI}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -123,7 +123,7 @@
                             <uuid>7ec0fb092ec14c01b800b8e1ecf7d2b3</uuid>
                             <name>BGP Out Prefixes for Peer {#IP_ADDRESS} AFI {#AFI} SAFI {#SAFI}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-BGP4-MIB::bgpPrefixCountersOutPrefixes.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}</snmp_oid>
+                            <snmp_oid>get[DMOS-BGP4-MIB::bgpPrefixCountersOutPrefixes.{#IP_ADDRESS_TYPE}.{#IP_ADDRESS_SIZE}.{#IP_ADDRESS_SNMP}.{#AFI}.{#SAFI}]</snmp_oid>
                             <key>bgpPrefixCountersOutPrefixes.[{#IP_ADDRESS}.{#AFI}.{#SAFI}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -212,7 +212,7 @@
                             <uuid>0d2052b54f0446dd9199b15460521341</uuid>
                             <name>BGP Established Transitions for Peer {#SNMPVALUE}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>BGP4-MIB::bgpPeerFsmEstablishedTransitions.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[BGP4-MIB::bgpPeerFsmEstablishedTransitions.{#SNMPINDEX}]</snmp_oid>
                             <key>bgpPeerFsmEstablishedTransitions.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -226,7 +226,7 @@
                             <uuid>7f4878d698d4484f97ee6b3b139eac16</uuid>
                             <name>BGP In Total Messages for Peer {#SNMPVALUE}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>BGP4-MIB::bgpPeerInTotalMessages.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[BGP4-MIB::bgpPeerInTotalMessages.{#SNMPINDEX}]</snmp_oid>
                             <key>bgpPeerInTotalMessages.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -240,7 +240,7 @@
                             <uuid>8a1faadf77824f26a0104f3b7a09a4a1</uuid>
                             <name>BGP In Updates for Peer {#SNMPVALUE}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>BGP4-MIB::bgpPeerInUpdates.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[BGP4-MIB::bgpPeerInUpdates.{#SNMPINDEX}]</snmp_oid>
                             <key>bgpPeerInUpdates.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -254,7 +254,7 @@
                             <uuid>d17cde45481c4f99a2afafe710f8f21a</uuid>
                             <name>BGP Out Total Messages for Peer {#SNMPVALUE}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>BGP4-MIB::bgpPeerOutTotalMessages.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[BGP4-MIB::bgpPeerOutTotalMessages.{#SNMPINDEX}]</snmp_oid>
                             <key>bgpPeerOutTotalMessages.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -268,7 +268,7 @@
                             <uuid>b3c8d724a3534254a5ca69b5d4130939</uuid>
                             <name>BGP Out Updates for Peer {#SNMPVALUE}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>BGP4-MIB::bgpPeerOutUpdates.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[BGP4-MIB::bgpPeerOutUpdates.{#SNMPINDEX}]</snmp_oid>
                             <key>bgpPeerOutUpdates.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -282,7 +282,7 @@
                             <uuid>6a2c1f7e4626458399322614b99ca7b2</uuid>
                             <name>BGP Peer {#SNMPVALUE} State</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>BGP4-MIB::bgpPeerState.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[BGP4-MIB::bgpPeerState.{#SNMPINDEX}]</snmp_oid>
                             <key>bgpPeerState.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <valuemap>

--- a/template_dmos_eaps/dmos_eaps_mib_zabbix_template.xml
+++ b/template_dmos_eaps/dmos_eaps_mib_zabbix_template.xml
@@ -40,7 +40,7 @@
                             <uuid>0b18078e7cf6445eb50de55bf2ffc73c</uuid>
                             <name>EAPS  {#EAPS_ID} Healt Check State</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-EAPS::eapsDomainHealthCheckState.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-EAPS::eapsDomainHealthCheckState.{#SNMPINDEX}]</snmp_oid>
                             <key>eapsDomainHealthCheckState.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <valuemap>
@@ -57,7 +57,7 @@
                             <uuid>975af9507c724ce1a24b3008e0ce93ad</uuid>
                             <name>EAPS  {#EAPS_ID} Domain ID</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-EAPS::eapsDomainID.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-EAPS::eapsDomainID.{#SNMPINDEX}]</snmp_oid>
                             <key>eapsDomainID.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -71,7 +71,7 @@
                             <uuid>0ba08fcf683d45e388c1ace788d13890</uuid>
                             <name>EAPS  {#EAPS_ID} Domain Mode</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-EAPS::eapsDomainMode.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-EAPS::eapsDomainMode.{#SNMPINDEX}]</snmp_oid>
                             <key>eapsDomainMode.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <valuemap>
@@ -88,7 +88,7 @@
                             <uuid>6e0a1d6b7fd1494585df336868c08b84</uuid>
                             <name>EAPS {#EAPS_ID} Domain Name</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-EAPS::eapsDomainName.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-EAPS::eapsDomainName.{#SNMPINDEX}]</snmp_oid>
                             <key>eapsDomainName.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <value_type>TEXT</value_type>
@@ -103,7 +103,7 @@
                             <uuid>553410f9b52a496baf34ffb0733f8387</uuid>
                             <name>EAPS  {#EAPS_ID} Domain Primary Port State</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-EAPS::eapsDomainPrimaryPortState.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-EAPS::eapsDomainPrimaryPortState.{#SNMPINDEX}]</snmp_oid>
                             <key>eapsDomainPrimaryPortState.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <valuemap>
@@ -120,7 +120,7 @@
                             <uuid>24699076ad6d470fb1ee44515a26785f</uuid>
                             <name>EAPS {#EAPS_ID} Domain Secondary Port State</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-EAPS::eapsDomainSecondaryPortState.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-EAPS::eapsDomainSecondaryPortState.{#SNMPINDEX}]</snmp_oid>
                             <key>eapsDomainSecondaryPortState.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <valuemap>
@@ -137,7 +137,7 @@
                             <uuid>1c9fd3032bfa44dead55429b2847be18</uuid>
                             <name>EAPS  {#EAPS_ID} Domain State</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-EAPS::eapsDomainState.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-EAPS::eapsDomainState.{#SNMPINDEX}]</snmp_oid>
                             <key>eapsDomainState.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <valuemap>

--- a/template_dmos_erps/dmos_erps_mib_zabbix_template.xml
+++ b/template_dmos_erps/dmos_erps_mib_zabbix_template.xml
@@ -40,7 +40,7 @@
                             <uuid>9545416fbb174afb9d2651eeaaf2ffb7</uuid>
                             <name>ERPS Ring {#ERPS_RING_ID} Control VLAN</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ERPS-MIB::erpsRingControlVlan.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ERPS-MIB::erpsRingControlVlan.{#SNMPINDEX}]</snmp_oid>
                             <key>erpsRingControlVlan.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -54,7 +54,7 @@
                             <uuid>7a1b8ecfd2b647b3bfba26e8b2e0bdc8</uuid>
                             <name>ERPS Ring {#ERPS_RING_ID} ID</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ERPS-MIB::erpsRingId.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ERPS-MIB::erpsRingId.{#SNMPINDEX}]</snmp_oid>
                             <key>erpsRingId.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <tags>
@@ -68,7 +68,7 @@
                             <uuid>4f551a3f069d4dc195e485aea5a40d80</uuid>
                             <name>ERPS Ring {#ERPS_RING_ID} Name</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ERPS-MIB::erpsRingName.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ERPS-MIB::erpsRingName.{#SNMPINDEX}]</snmp_oid>
                             <key>erpsRingName.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <value_type>TEXT</value_type>
@@ -83,7 +83,7 @@
                             <uuid>d6bce20f12dd474aac23364493d052d8</uuid>
                             <name>ERPS Ring {#ERPS_RING_ID} Parent Ring</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ERPS-MIB::erpsRingParentRing.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ERPS-MIB::erpsRingParentRing.{#SNMPINDEX}]</snmp_oid>
                             <key>erpsRingParentRing.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <value_type>TEXT</value_type>
@@ -98,7 +98,7 @@
                             <uuid>2c0c81328ad24fb889334554cf7d8d42</uuid>
                             <name>ERPS Ring {#ERPS_RING_ID} Port0</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ERPS-MIB::erpsRingPort0.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ERPS-MIB::erpsRingPort0.{#SNMPINDEX}]</snmp_oid>
                             <key>erpsRingPort0.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <value_type>TEXT</value_type>
@@ -113,7 +113,7 @@
                             <uuid>6c36755f41aa4582a265cc008deb319d</uuid>
                             <name>ERPS Ring {#ERPS_RING_ID} Port0 RPL Role</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ERPS-MIB::erpsRingPort0RplRole.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ERPS-MIB::erpsRingPort0RplRole.{#SNMPINDEX}]</snmp_oid>
                             <key>erpsRingPort0RplRole.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <valuemap>
@@ -130,7 +130,7 @@
                             <uuid>3e0eab10d6484494ab561b2fcaa7dc63</uuid>
                             <name>ERPS Ring {#ERPS_RING_ID} Port0 State</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ERPS-MIB::erpsRingPort0State.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ERPS-MIB::erpsRingPort0State.{#SNMPINDEX}]</snmp_oid>
                             <key>erpsRingPort0State.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <valuemap>
@@ -147,7 +147,7 @@
                             <uuid>09e768a303b240c89982b300a3ab383f</uuid>
                             <name>ERPS Ring {#ERPS_RING_ID} Port1</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ERPS-MIB::erpsRingPort1.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ERPS-MIB::erpsRingPort1.{#SNMPINDEX}]</snmp_oid>
                             <key>erpsRingPort1.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <value_type>TEXT</value_type>
@@ -162,7 +162,7 @@
                             <uuid>1f62364679304de1baa1b0eb4b1f0c07</uuid>
                             <name>ERPS Ring {#ERPS_RING_ID} Port1 RPL Role</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ERPS-MIB::erpsRingPort1RplRole.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ERPS-MIB::erpsRingPort1RplRole.{#SNMPINDEX}]</snmp_oid>
                             <key>erpsRingPort1RplRole.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <valuemap>
@@ -179,7 +179,7 @@
                             <uuid>b0004992f9df42a199afeadaf4a1e580</uuid>
                             <name>ERPS Ring {#ERPS_RING_ID} Port1 State</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ERPS-MIB::erpsRingPort1State.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ERPS-MIB::erpsRingPort1State.{#SNMPINDEX}]</snmp_oid>
                             <key>erpsRingPort1State.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <valuemap>
@@ -196,7 +196,7 @@
                             <uuid>abda0b762df54bccad760b43afab9629</uuid>
                             <name>ERPS Ring {#ERPS_RING_ID} State</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ERPS-MIB::erpsRingState.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ERPS-MIB::erpsRingState.{#SNMPINDEX}]</snmp_oid>
                             <key>erpsRingState.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <valuemap>
@@ -221,7 +221,7 @@
                             <uuid>b14d4684e0c044649d4c96acc3ebba6c</uuid>
                             <name>ERPS Ring {#ERPS_RING_ID} Type</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ERPS-MIB::erpsRingType.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ERPS-MIB::erpsRingType.{#SNMPINDEX}]</snmp_oid>
                             <key>erpsRingType.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <valuemap>

--- a/template_dmos_gpon/dmos_gpon_mib_zabbix_template.xml
+++ b/template_dmos_gpon/dmos_gpon_mib_zabbix_template.xml
@@ -7,7 +7,7 @@
             <name>DM - Templates</name>
         </template_group>
         <template_group>
-            <uuid>83761f47e4884f74a1c6851e01014167</uuid>
+            <uuid>90fc9cada07942e49a43856c9ec5e8d3</uuid>
             <name>DmOS</name>
         </template_group>
         <template_group>
@@ -57,7 +57,7 @@
                             <uuid>a6e307748b4b4bf6940466a68d284b8c</uuid>
                             <name>AdminStatus - ONU {#ONUIFDESCR}({#ONUIFNAME})</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>onuifAdminStatus.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[onuifAdminStatus.{#SNMPINDEX}]</snmp_oid>
                             <key>onuifAdminStatus[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>1w</history>
@@ -78,7 +78,7 @@
                             <uuid>60cf179687d84a9fa33183cf7d9e897a</uuid>
                             <name>Power RX - ONU {#ONUIFDESCR}({#ONUIFNAME})</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>onuIfOnuPowerRx.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[onuIfOnuPowerRx.{#SNMPINDEX}]</snmp_oid>
                             <key>onuIfOnuPowerRx[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>1w</history>
@@ -106,7 +106,7 @@ last(/DM Template - DmOS GPON/onuIfOnuPowerRx[{#SNMPINDEX}])&gt;-8.0</expression
                             <uuid>63ac2eafe8744ecd90c17d0c1c55e78f</uuid>
                             <name>Power TX - ONU {#ONUIFDESCR}({#ONUIFNAME})</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>onuIfOnuPowerTx.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[onuIfOnuPowerTx.{#SNMPINDEX}]</snmp_oid>
                             <key>onuIfOnuPowerTx[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>1w</history>
@@ -135,7 +135,7 @@ last(/DM Template - DmOS GPON/onuIfOnuPowerTx[{#SNMPINDEX}])&lt;-0.5</expression
                             <uuid>528e40b010f842f2a619d7b67835b38a</uuid>
                             <name>Status - ONU {#ONUIFDESCR}</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>onuifOperStatus.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[onuifOperStatus.{#SNMPINDEX}]</snmp_oid>
                             <key>onuifOperStatus[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>1w</history>
@@ -169,7 +169,7 @@ last(/DM Template - DmOS GPON/onuIfOnuPowerTx[{#SNMPINDEX}])&lt;-0.5</expression
                             <uuid>d2da81ba0c204ff482f568d2bf47cb64</uuid>
                             <name>Uptime - ONU {#ONUIFDESCR}({#ONUIFNAME})</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>onuSysUpTime.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[onuSysUpTime.{#SNMPINDEX}]</snmp_oid>
                             <key>onuSysUpTime[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>1w</history>
@@ -247,7 +247,7 @@ last(/DM Template - DmOS GPON/onuIfOnuPowerTx[{#SNMPINDEX}])&lt;-0.5</expression
                             <uuid>6a95738c37b649efada775501d2a5e37</uuid>
                             <name>ONU {#ONUIFDESCR}({#ONUIFNAME}): GEM Input Octets</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>onuGemInOctets.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[onuGemInOctets.{#SNMPINDEX}]</snmp_oid>
                             <key>onuGemInOctets[{#SNMPINDEX}]</key>
                             <units>bps</units>
                             <preprocessing>
@@ -272,7 +272,7 @@ last(/DM Template - DmOS GPON/onuIfOnuPowerTx[{#SNMPINDEX}])&lt;-0.5</expression
                             <uuid>d10076c5cae14124bd096217bb2ab8ee</uuid>
                             <name>ONU {#ONUIFDESCR}({#ONUIFNAME}): GEM Output Octets</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>onuGemOutOctets.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[onuGemOutOctets.{#SNMPINDEX}]</snmp_oid>
                             <key>onuGemOutOctets[{#SNMPINDEX}]</key>
                             <units>bps</units>
                             <preprocessing>
@@ -346,7 +346,7 @@ last(/DM Template - DmOS GPON/onuIfOnuPowerTx[{#SNMPINDEX}])&lt;-0.5</expression
                             <uuid>ab601048b8fc40c5b68ce9d29a9c1f74</uuid>
                             <name>ONU {#ONUIFDESCR}({#ONUIFNAME}): Input Octets</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>onuIfStatisticsInOctets.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[onuIfStatisticsInOctets.{#SNMPINDEX}]</snmp_oid>
                             <key>onuifInOctets[{#SNMPINDEX}]</key>
                             <units>bps</units>
                             <preprocessing>
@@ -371,7 +371,7 @@ last(/DM Template - DmOS GPON/onuIfOnuPowerTx[{#SNMPINDEX}])&lt;-0.5</expression
                             <uuid>819a94503a1d4e1ab2278189245dc7e6</uuid>
                             <name>ONU {#ONUIFDESCR}({#ONUIFNAME}): Output Octets</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>onuIfStatisticsOutOctets.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[onuIfStatisticsOutOctets.{#SNMPINDEX}]</snmp_oid>
                             <key>onuifOutOctets[{#SNMPINDEX}]</key>
                             <units>bps</units>
                             <preprocessing>
@@ -396,7 +396,7 @@ last(/DM Template - DmOS GPON/onuIfOnuPowerTx[{#SNMPINDEX}])&lt;-0.5</expression
                             <uuid>fc6996bcd36c4f9ca7891a3cc32533a6</uuid>
                             <name>ONU {#ONUIFDESCR}({#ONUIFNAME}): Input Bandwidth Usage</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>onuIfStatisticsInBwUsage.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[onuIfStatisticsInBwUsage.{#SNMPINDEX}]</snmp_oid>
                             <key>onuInBwUsage[{#SNMPINDEX}]</key>
                             <delay>15m</delay>
                             <units>bps</units>
@@ -411,7 +411,7 @@ last(/DM Template - DmOS GPON/onuIfOnuPowerTx[{#SNMPINDEX}])&lt;-0.5</expression
                             <uuid>89840e1f3b3047ebb492ab81e661fd83</uuid>
                             <name>ONU {#ONUIFDESCR}({#ONUIFNAME}): Output Bandwidth Usage</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>onuIfStatisticsOutBwUsage.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[onuIfStatisticsOutBwUsage.{#SNMPINDEX}]</snmp_oid>
                             <key>onuOutBwUsage[{#SNMPINDEX}]</key>
                             <delay>15m</delay>
                             <units>bps</units>

--- a/template_dmos_gpon_counting/dmos_gpon_counting_mib_zabbix_template.xml
+++ b/template_dmos_gpon_counting/dmos_gpon_counting_mib_zabbix_template.xml
@@ -7,7 +7,7 @@
             <name>DM - Templates</name>
         </template_group>
         <template_group>
-            <uuid>83761f47e4884f74a1c6851e01014167</uuid>
+            <uuid>90fc9cada07942e49a43856c9ec5e8d3</uuid>
             <name>DmOS</name>
         </template_group>
     </template_groups>
@@ -30,7 +30,7 @@
                     <uuid>1d4cc98b02164939b56df7c64285c22c</uuid>
                     <name>Global Down Onus</name>
                     <type>SNMP_AGENT</type>
-                    <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfGlobalDownOnus.0</snmp_oid>
+                    <snmp_oid>get[DMOS-ONU-COUNTING-MIB::ponIfGlobalDownOnus.0]</snmp_oid>
                     <key>ponIfGlobalDownOnus</key>
                     <delay>10m</delay>
                     <history>90d</history>
@@ -45,7 +45,7 @@
                     <uuid>5fb0d6a2a7a74ab69c66bdc17b19ec41</uuid>
                     <name>Global Non Provisioned Onus</name>
                     <type>SNMP_AGENT</type>
-                    <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfGlobalNonProvisionedOnus.0</snmp_oid>
+                    <snmp_oid>get[DMOS-ONU-COUNTING-MIB::ponIfGlobalNonProvisionedOnus.0]</snmp_oid>
                     <key>ponIfGlobalNonProvisionedOnus</key>
                     <delay>10m</delay>
                     <history>90d</history>
@@ -60,7 +60,7 @@
                     <uuid>caffa3cd50744c46bd9e461d4eb0aa74</uuid>
                     <name>Global Total Onus</name>
                     <type>SNMP_AGENT</type>
-                    <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfGlobalTotalOnus.0</snmp_oid>
+                    <snmp_oid>get[DMOS-ONU-COUNTING-MIB::ponIfGlobalTotalOnus.0]</snmp_oid>
                     <key>ponIfGlobalTotalOnus</key>
                     <delay>10m</delay>
                     <history>90d</history>
@@ -75,7 +75,7 @@
                     <uuid>919e31efcea64054b672141c6118da83</uuid>
                     <name>Global Up Onus</name>
                     <type>SNMP_AGENT</type>
-                    <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfGlobalUpOnus.0</snmp_oid>
+                    <snmp_oid>get[DMOS-ONU-COUNTING-MIB::ponIfGlobalUpOnus.0]</snmp_oid>
                     <key>ponIfGlobalUpOnus</key>
                     <delay>10m</delay>
                     <history>90d</history>
@@ -103,7 +103,7 @@
                             <uuid>58addc1c64cf46dba0dd03a9304f1589</uuid>
                             <name>PON {#PONIFDESCR}: Down Onus</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfDownOnus.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ONU-COUNTING-MIB::ponIfDownOnus.{#SNMPINDEX}]</snmp_oid>
                             <key>pon.if[ponIfDownOnus.{#SNMPINDEX}]</key>
                             <delay>10m</delay>
                             <tags>
@@ -117,7 +117,7 @@
                             <uuid>88fd6dd121f14a66b8c5213cb736b775</uuid>
                             <name>PON {#PONIFDESCR}: Non Provisioned Onus</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfNonProvisionedOnus.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ONU-COUNTING-MIB::ponIfNonProvisionedOnus.{#SNMPINDEX}]</snmp_oid>
                             <key>pon.if[ponIfNonProvisionedOnus.{#SNMPINDEX}]</key>
                             <delay>10m</delay>
                             <tags>
@@ -131,7 +131,7 @@
                             <uuid>42d1217ed7a4480ab1addb8f659a6e9e</uuid>
                             <name>PON {#PONIFDESCR}: Total ONUs</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfTotalOnus.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ONU-COUNTING-MIB::ponIfTotalOnus.{#SNMPINDEX}]</snmp_oid>
                             <key>pon.if[ponIfTotalOnus.{#SNMPINDEX}]</key>
                             <delay>10m</delay>
                             <tags>
@@ -145,7 +145,7 @@
                             <uuid>1ddf5a94d1a341d78c075f2246ad8cb6</uuid>
                             <name>PON {#PONIFDESCR}: Up Onus</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-ONU-COUNTING-MIB::ponIfUpOnus.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-ONU-COUNTING-MIB::ponIfUpOnus.{#SNMPINDEX}]</snmp_oid>
                             <key>pon.if[ponIfUpOnus.{#SNMPINDEX}]</key>
                             <delay>10m</delay>
                             <tags>

--- a/template_dmos_transceivers/dmos_transceivers_mib_zabbix_template.xml
+++ b/template_dmos_transceivers/dmos_transceivers_mib_zabbix_template.xml
@@ -31,7 +31,7 @@
                             <uuid>5b92801bb0624fb5bf7cdb810edd1065</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Operational Status</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>ifOperStatus.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[ifOperStatus.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInterfaceOperStatus.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>730d</history>
@@ -49,7 +49,7 @@
                             <uuid>d98938cd1bda445b92d1d9c154132cb1</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} Laser Wavelength</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoLaserWavelength.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoLaserWavelength.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryLaserWavelength.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -65,7 +65,7 @@
                             <uuid>61a059bb29804b0c921627f84c01d64e</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} RX Signal High</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoRxPowerThresholdsAlarmHigh.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoRxPowerThresholdsAlarmHigh.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryRxSignalHigh.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -82,7 +82,7 @@
                             <uuid>c6ebbaf3468645678b679b2c8e2647be</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} RX Signal Low</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoRxPowerThresholdsAlarmLow.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoRxPowerThresholdsAlarmLow.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryRxSignalLow.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -99,7 +99,7 @@
                             <uuid>7f21eea6840d4fb497160faaaf7de288</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} RX Signal Warning High</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoRxPowerThresholdsWarningHigh.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoRxPowerThresholdsWarningHigh.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryRxSignalWarningHigh.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -116,7 +116,7 @@
                             <uuid>efdbbe8889a84c838da51a38bf9928e6</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} RX Signal Warning Low</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoRxPowerThresholdsWarningLow.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoRxPowerThresholdsWarningLow.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryRxSignalWarningLow.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -133,7 +133,7 @@
                             <uuid>2d3d8f6e540040eeb2922396c3e13b4e</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} Temperature Alarm High</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoTemperatureThresholdsAlarmHigh.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoTemperatureThresholdsAlarmHigh.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryTempHigh.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -150,7 +150,7 @@
                             <uuid>133275d2430c4c37b97695ed26d97b0b</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} Temperature Alarm Low</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoTemperatureThresholdsAlarmLow.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoTemperatureThresholdsAlarmLow.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryTempLow.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -167,7 +167,7 @@
                             <uuid>6412b127d3f44815958299292a929911</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} Temperature Warnig High</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoTemperatureThresholdsWarningHigh.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoTemperatureThresholdsWarningHigh.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryTempWarningHigh.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -184,7 +184,7 @@
                             <uuid>7b95b947a79a437882bde170caef883b</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} Temperature Warnig Low</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoTemperatureThresholdsWarningLow.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoTemperatureThresholdsWarningLow.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryTempWarningLow.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -201,7 +201,7 @@
                             <uuid>9ea2716bd611440596136b6f52a9f8e9</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} TX Signal High</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoTxPowerThresholdsAlarmHigh.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoTxPowerThresholdsAlarmHigh.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryTxSignalHigh.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -218,7 +218,7 @@
                             <uuid>88c4ae309efb442e8703ce8e66742a7b</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} TX Signal Low</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoTxPowerThresholdsAlarmLow.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoTxPowerThresholdsAlarmLow.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryTxSignalLow.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -235,7 +235,7 @@
                             <uuid>8fe4288f78c24014b10447c35b0cae8f</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} TX Signal Warning High</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoTxPowerThresholdsWarningHigh.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoTxPowerThresholdsWarningHigh.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryTxSignalWarningHigh.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -252,7 +252,7 @@
                             <uuid>3105d16c144f4f889b05305afe4b24b9</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Inventory SN {#TCN_SN} TX Signal Warning Low</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-INVENTORY-MIB::transceiverInventoryInfoTxPowerThresholdsWarningLow.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-INVENTORY-MIB::transceiverInventoryInfoTxPowerThresholdsWarningLow.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverInventoryTxSignalWarningLow.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>
@@ -269,7 +269,7 @@
                             <uuid>3b66fda2858e455eab6abddd68660605</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Status SN {#TCN_SN} Rx Power Lane 1</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-TRANSCEIVER-MIB::laneRxPower.{#SNMPINDEX}.1</snmp_oid>
+                            <snmp_oid>get[DMOS-TRANSCEIVER-MIB::laneRxPower.{#SNMPINDEX}.1]</snmp_oid>
                             <key>transceiverStatusLane1RxPower.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>730d</history>
@@ -295,7 +295,7 @@
                             <uuid>ba9b3caf2f604c36889eca98fc4c50da</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Status SN {#TCN_SN} Tx Power Lane 1</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-TRANSCEIVER-MIB::laneTxPower.{#SNMPINDEX}.1</snmp_oid>
+                            <snmp_oid>get[DMOS-TRANSCEIVER-MIB::laneTxPower.{#SNMPINDEX}.1]</snmp_oid>
                             <key>transceiverStatusLane1TxPower.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>730d</history>
@@ -321,7 +321,7 @@
                             <uuid>00312904a153482a901cc043aef7c227</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Status SN {#TCN_SN} Lane Counter</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-TRANSCEIVER-MIB::laneCount.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-TRANSCEIVER-MIB::laneCount.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverStatusLaneCount.[{#SNMPINDEX}]</key>
                             <delay>5m</delay>
                             <history>730d</history>
@@ -337,7 +337,7 @@
                             <uuid>e59f754dcfbf41599ae5ba40a5d6db85</uuid>
                             <name>Interface {#IFDESCR}({#IFALIAS}): Transceiver Status SN {#TCN_SN} Temperature</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DMOS-TRANSCEIVER-MIB::temperature.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DMOS-TRANSCEIVER-MIB::temperature.{#SNMPINDEX}]</snmp_oid>
                             <key>transceiverStatusTemp.[{#SNMPINDEX}]</key>
                             <delay>1d</delay>
                             <history>730d</history>

--- a/template_icmp_probe/dm_template_icmp_probe.xml
+++ b/template_icmp_probe/dm_template_icmp_probe.xml
@@ -32,14 +32,14 @@
                             <uuid>fb903258bebb4b48af99fbc75b1c663d</uuid>
                             <name>ICMP Probe - {#SNMPINDEX} - Current Average Ping Round-Trip-Time</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DATACOM-PING-MIB::pingResultsAverageRtt.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DATACOM-PING-MIB::pingResultsAverageRtt.{#SNMPINDEX}]</snmp_oid>
                             <key>pingResultsAverageRtt.[{#SNMPINDEX}]</key>
                         </item_prototype>
                         <item_prototype>
                             <uuid>ad24d50d7b844d50b59dc3c655c87884</uuid>
                             <name>ICMP Probe - {#SNMPINDEX} - Target Address</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DATACOM-PING-MIB::pingResultsIpTargetAddress.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DATACOM-PING-MIB::pingResultsIpTargetAddress.{#SNMPINDEX}]</snmp_oid>
                             <key>pingResultsIpTargetAddress.[{#SNMPINDEX}]</key>
                             <value_type>CHAR</value_type>
                         </item_prototype>
@@ -47,7 +47,7 @@
                             <uuid>6e0e3aab6a5744c5ac952e6f751bffaf</uuid>
                             <name>ICMP Probe - {#SNMPINDEX} - Target Address Type</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DATACOM-PING-MIB::pingResultsIpTargetAddressType.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DATACOM-PING-MIB::pingResultsIpTargetAddressType.{#SNMPINDEX}]</snmp_oid>
                             <key>pingResultsIpTargetAddressType.[{#SNMPINDEX}]</key>
                             <value_type>CHAR</value_type>
                         </item_prototype>
@@ -55,7 +55,7 @@
                             <uuid>85fd5e03256840bbba03ed9c9ab0feee</uuid>
                             <name>ICMP Probe - {#SNMPINDEX} - Date and Time When The Last Response Was Received For A Probe</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DATACOM-PING-MIB::pingResultsLastGoodProbe.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DATACOM-PING-MIB::pingResultsLastGoodProbe.{#SNMPINDEX}]</snmp_oid>
                             <key>pingResultsLastGoodProbe.[{#SNMPINDEX}]</key>
                             <value_type>CHAR</value_type>
                         </item_prototype>
@@ -63,21 +63,21 @@
                             <uuid>875a63be97f84ed1a4b883d4d47ba697</uuid>
                             <name>ICMP Probe - {#SNMPINDEX} - Maximum Ping Round-Trip-Time</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DATACOM-PING-MIB::pingResultsMaxRtt.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DATACOM-PING-MIB::pingResultsMaxRtt.{#SNMPINDEX}]</snmp_oid>
                             <key>pingResultsMaxRtt.[{#SNMPINDEX}]</key>
                         </item_prototype>
                         <item_prototype>
                             <uuid>03f6fcfe5e8e46c6854398b50ee2d30c</uuid>
                             <name>ICMP Probe - {#SNMPINDEX} - Minimum Ping Round-Trip-Time Received</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DATACOM-PING-MIB::pingResultsMinRtt.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DATACOM-PING-MIB::pingResultsMinRtt.{#SNMPINDEX}]</snmp_oid>
                             <key>pingResultsMinRtt[{#SNMPINDEX}]</key>
                         </item_prototype>
                         <item_prototype>
                             <uuid>1149d119cd8b40db96e0e8f3081822e2</uuid>
                             <name>ICMP Probe - {#SNMPINDEX} - Operational State</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DATACOM-PING-MIB::pingResultsOperStatus.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DATACOM-PING-MIB::pingResultsOperStatus.{#SNMPINDEX}]</snmp_oid>
                             <key>pingResultsOperStatus.[{#SNMPINDEX}]</key>
                             <trigger_prototypes>
                                 <trigger_prototype>
@@ -92,21 +92,21 @@
                             <uuid>05278e978bb74ec1abcafd76ed54f9ee</uuid>
                             <name>ICMP Probe - {#SNMPINDEX} - Number Of Responses Received</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DATACOM-PING-MIB::pingResultsProbeResponses.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DATACOM-PING-MIB::pingResultsProbeResponses.{#SNMPINDEX}]</snmp_oid>
                             <key>pingResultsProbeResponses.[{#SNMPINDEX}]</key>
                         </item_prototype>
                         <item_prototype>
                             <uuid>b6bf550bdaea458db2d998f325bef364</uuid>
                             <name>ICMP Probe - {#SNMPINDEX} - Sum Of The Squares For All Ping Responses Received</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DATACOM-PING-MIB::pingResultsRttSumOfSquares.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DATACOM-PING-MIB::pingResultsRttSumOfSquares.{#SNMPINDEX}]</snmp_oid>
                             <key>pingResultsRttSumOfSquares.[{#SNMPINDEX}]</key>
                         </item_prototype>
                         <item_prototype>
                             <uuid>c48b8774202641398eb85603762164ed</uuid>
                             <name>ICMP Probe - {#SNMPINDEX} - Number Of Probes Sent</name>
                             <type>SNMP_AGENT</type>
-                            <snmp_oid>DATACOM-PING-MIB::pingResultsSentProbes.{#SNMPINDEX}</snmp_oid>
+                            <snmp_oid>get[DATACOM-PING-MIB::pingResultsSentProbes.{#SNMPINDEX}]</snmp_oid>
                             <key>pingResultsSentProbes.[{#SNMPINDEX}]</key>
                         </item_prototype>
                     </item_prototypes>


### PR DESCRIPTION
Zabbix version 7.0.0 introduces asynchronous get as a replacement for the traditional synchronous get method.

Using the traditional synchronous get mode, the poller waits for a response from the device to fulfill a new request. Even when increasing the number of pollers in scenarios with many hosts and items, the poller process will experience high resource consumption.