### PR TITLE
Change uptime object in DmOS template

### DIFF
--- a/template_dmos/dmos_zabbix_template.xml
+++ b/template_dmos/dmos_zabbix_template.xml
@@ -94,20 +94,12 @@
                     <uuid>2fcbe0e771e9486e9efab72e5957d635</uuid>
                     <name>Device uptime</name>
                     <type>SNMP_AGENT</type>
-                    <snmp_oid>get[SNMPv2-MIB::sysUpTime.0]</snmp_oid>
+                    <snmp_oid>get[DMOS-SYSMON-MIB::cpuSysUptime.0]</snmp_oid>
                     <key>sysUpTime</key>
                     <delay>60m</delay>
                     <history>7d</history>
                     <units>uptime</units>
                     <description>The time since the network management portion of the system was last re-initialized.</description>
-                    <preprocessing>
-                        <step>
-                            <type>MULTIPLIER</type>
-                            <parameters>
-                                <parameter>0.01</parameter>
-                            </parameters>
-                        </step>
-                    </preprocessing>
                     <tags>
                         <tag>
                             <tag>Application</tag>


### PR DESCRIPTION
The proprietary object use 64 bits counter which does not overflow after 497 days and does not restart counter if SNMP agent is restarted.